### PR TITLE
feat: Normalize headers to lowercase keys and export WebhookVerificationError

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,1 +1,2 @@
 export * from './seam-webhook.js'
+export { WebhookVerificationError as SeamWebhookVerificationError } from 'svix'

--- a/src/lib/seam-webhook.ts
+++ b/src/lib/seam-webhook.ts
@@ -9,6 +9,10 @@ export class SeamWebhook {
   }
 
   verify(payload: string, headers: Record<string, string>): SeamEvent {
-    return this.#webhook.verify(payload, headers) as SeamEvent
+    const normalizedHeaders = Object.fromEntries(
+      Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value])
+    )
+
+    return this.#webhook.verify(payload, normalizedHeaders) as SeamEvent
   }
 }

--- a/src/lib/seam-webhook.ts
+++ b/src/lib/seam-webhook.ts
@@ -10,7 +10,7 @@ export class SeamWebhook {
 
   verify(payload: string, headers: Record<string, string>): SeamEvent {
     const normalizedHeaders = Object.fromEntries(
-      Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value])
+      Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]),
     )
 
     return this.#webhook.verify(payload, normalizedHeaders) as SeamEvent


### PR DESCRIPTION
Closes https://github.com/seamapi/javascript-webhook/issues/7

- **Normalize headers to lowercase before passing to svix**
- **Export Seam aliased svix WebhookVerificationError**
